### PR TITLE
Adds support for Markdown and HTML message formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@ To send a message:
 telegram-send "hello, world"
 ```
 
+To send a message using Markdown or HTML formatting:
+```shell
+telegram-send --format markdown "Only the *bold* use _italics_"
+telegram-send --format html "<pre>fixed-width messages</pre> are <i>also</i> supported"
+```
+(for more information on supported formatting, see the [formatting documentation](https://core.telegram.org/bots/api#formatting-options))
+
 To send a file:
 ``` shell
 telegram-send --file document.pdf

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     license="GPLv3+",
 
     py_modules=["telegram_send"],
-    install_requires=["python-telegram-bot", "colorama", "appdirs"],
+    install_requires=["python-telegram-bot>=2.8.3", "colorama", "appdirs"],
     entry_points={"console_scripts": ["telegram-send=telegram_send:main"]},
 
     author="Rahiel Kasim",

--- a/telegram_send.py
+++ b/telegram_send.py
@@ -42,6 +42,7 @@ def main():
     parser.add_argument("message", help="message(s) to send", nargs='*')
     parser.add_argument("-c", "--configure", help="configure %(prog)s", action="store_true")
     parser.add_argument("--configure-channel", help="configure %(prog)s for a channel", action="store_true")
+    parser.add_argument("--format", default="text", dest="parse_mode", choices=['text', 'markdown', 'html'], help="How to format message when sending to telegram. Choose from 'text', 'markdown', or 'html'")
     parser.add_argument("-f", "--file", help="send file(s)", nargs='+', type=argparse.FileType("rb"))
     parser.add_argument("-i", "--image", help="send image(s)", nargs='+', type=argparse.FileType("rb"))
     parser.add_argument("--caption", help="caption for image(s)", nargs='+')
@@ -61,7 +62,7 @@ def main():
         return clean()
 
     try:
-        send(messages=args.message, conf=args.conf, files=args.file, images=args.image, captions=args.caption)
+        send(messages=args.message, conf=args.conf, parse_mode=args.parse_mode, files=args.file, images=args.image, captions=args.caption)
     except ConfigError as e:
         print(markup(str(e), "red"))
         cmd = "telegram-send --configure"
@@ -70,7 +71,7 @@ def main():
         print("Please run: " + markup(cmd, "bold"))
 
 
-def send(messages=None, conf=None, files=None, images=None, captions=None):
+def send(messages=None, conf=None, parse_mode=None, files=None, images=None, captions=None):
     """Send data over Telegram.
 
     Optional Args:
@@ -93,9 +94,16 @@ def send(messages=None, conf=None, files=None, images=None, captions=None):
 
     bot = telegram.Bot(token)
 
+    # We let the user specify "text" as a parse mode to be more explicit about
+    # the lack of formatting applied to the message, but "text" isn't a supported
+    # parse_mode in python-telegram-bot. Instead, set the parse_mode to None
+    # in this case.
+    if parse_mode == "text":
+        parse_mode = None
+
     if messages:
         for m in messages:
-            bot.sendMessage(chat_id=chat_id, text=m)
+            bot.sendMessage(chat_id=chat_id, text=m, parse_mode=parse_mode)
 
     if files:
         for f in files:


### PR DESCRIPTION
Lets the user specify a format to send the telegram message in. Can be one of
`text`, `markdown`, or `html`. Also adds some bare-bones docs for the feature.

This commit bumps the minimum version of python-telegram-bot to 2.8.3, as that
was the version which introduced Markdown formatting support. That version was
released in September of 2015, and the current version of that library is 5.3,
so this should be a fairly safe minimum to enforce.

I didn't bump the version, in case there's other changes you want to roll in.