### PR TITLE
Fixed bug sending message from stdin

### DIFF
--- a/telegram_send.py
+++ b/telegram_send.py
@@ -103,7 +103,7 @@ def main():
         if args.pre:
             message = pre(message)
         for c in conf:
-            send(messages=[message], conf=conf, parse_mode=args.parse_mode, silent=args.silent, disable_web_page_preview=args.disable_web_page_preview)
+            send(messages=[message], conf=c, parse_mode=args.parse_mode, silent=args.silent, disable_web_page_preview=args.disable_web_page_preview)
 
     try:
         if args.pre:


### PR DESCRIPTION
Fixed sending message from stdin.

echo "Test" | telegram_send -g --stdin

Traceback (most recent call last):
  File "/usr/local/bin/telegram-send", line 10, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.7/dist-packages/telegram_send.py", line 106, in main
    send(messages=[message], conf=conf, parse_mode=args.parse_mode, silent=args.silent, disable_web_page_preview=args.disable_web_page_preview)
  File "/usr/local/lib/python3.7/dist-packages/telegram_send.py", line 182, in send
    conf = expanduser(conf) if conf else get_config_path()
  File "/usr/lib/python3.7/posixpath.py", line 235, in expanduser
    path = os.fspath(path)
TypeError: expected str, bytes or os.PathLike object, not list