### PR TITLE
Add MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE.txt


### PR DESCRIPTION
Add the `LICENSE.txt` to `MANIFEST.in` so that it will be included in sdists and other packages.
This came up during packaging of telegram-send for conda-forge.

Also please submit a new release to pypi so this change will be tracked.