### PR TITLE
Add missing conf argument for delete

### DIFF
--- a/telegram_send/telegram_send.py
+++ b/telegram_send/telegram_send.py
@@ -119,7 +119,7 @@ def main():
         args.message = [message]
 
     try:
-        delete(args.delete)
+        delete(args.delete, conf=conf[0])
         message_ids = []
         for c in conf:
             message_ids += send(


### PR DESCRIPTION
Currently, if the default config file is missing, the tool always complains `Config not found` even when `--global-config` or `--config` is presented.

Because the `conf` argument of `delete` is missing, `user_config_dir/telegram-send.conf` will always be used in `delete`.