### PR TITLE
Added support for group topics

### DIFF
--- a/telegram_send/__init__.py
+++ b/telegram_send/__init__.py
@@ -1,4 +1,5 @@
-from .version import __version__
+# TODO: rollback to .version before sending PR
+from version import __version__
 from .telegram_send import configure, send
 
 

--- a/telegram_send/__init__.py
+++ b/telegram_send/__init__.py
@@ -1,5 +1,4 @@
-# TODO: rollback to .version before sending PR
-from version import __version__
+from .version import __version__
 from .telegram_send import configure, send
 
 

--- a/telegram_send/telegram_send.py
+++ b/telegram_send/telegram_send.py
@@ -33,9 +33,8 @@ import colorama
 import telegram
 from telegram.constants import MessageLimit
 
-# TODO: rollback to .version and .utils before sending PR
-from version import __version__
-from utils import pre_format, split_message, get_config_path, markup
+from .version import __version__
+from .utils import pre_format, split_message, get_config_path, markup
 
 try:
     import readline

--- a/telegram_send/telegram_send.py
+++ b/telegram_send/telegram_send.py
@@ -457,7 +457,7 @@ async def configure(conf, channel=False, group=False, fm_integration=False):
                 print("Error! {}".format(e))
 
         chat_id = update.message.chat_id
-        user = update.message.from_user.username or update.message.from_user.first_nam
+        user = update.message.from_user.username or update.message.from_user.first_name
         root_topic_message = None
 
         if update.message.chat.is_forum:

--- a/telegram_send/telegram_send.py
+++ b/telegram_send/telegram_send.py
@@ -553,7 +553,7 @@ class Settings(NamedTuple):
     reply_to_message_id: Union[int, str, None]
 
 
-def get_config_settings(conf=None, bot=None) -> Settings:
+def get_config_settings(conf=None) -> Settings:
     conf = expanduser(conf) if conf else get_config_path()
     config = configparser.ConfigParser()
     if not config.read(conf) or not config.has_section("telegram"):


### PR DESCRIPTION
This PR adds support for topic-structured groups, officially known as forums. This was requested in Issue #131. Legacy supergroup behaviour is unchanged; new logic is only applied when telegram_send detects that it is being configured to work inside a forum. Topic-separation works by replying to a "forum_topic_created" message. An additional configuration field was added to keep a permanent reference to this message, called "reply_to_message_id". If "reply_to_message_id" is present in the configuration, the bot will always reply to that message, which will result in a message appearing inside a topic. Examples of reworked logic are shown below:

**Legacy groups:**
<img width="400" alt="Legacy groups" src="https://github.com/rahiel/telegram-send/assets/40764618/8b606fe0-8717-4955-95d3-89194b1a0d0f">

**Forums:**
<img width="400" alt="Forums" src="https://github.com/rahiel/telegram-send/assets/40764618/0a7b8a29-b4f7-4973-a0d7-0dcb7b7eef99">

**Forums (alternated topic):**
<img width="400" alt="Forums (alternated topic)" src="https://github.com/rahiel/telegram-send/assets/40764618/934d97a4-40a7-414a-addf-1c60b1deebcf">


**New configuration:**
<img width="400" alt="New configuration" src="https://github.com/rahiel/telegram-send/assets/40764618/1fdcf1bf-89e8-4353-962b-8fdabac64bf2">

**Old configuration:**
<img width="400" alt="Old configuration" src="https://github.com/rahiel/telegram-send/assets/40764618/ff81c21a-2c67-4657-a4f1-53c000b3c88a">



